### PR TITLE
Fix directory inside of SDSS Montage Chart to use user folder instead of static folder

### DIFF
--- a/Astronomy/sdss_mosaics/SDSS_today.ipynb
+++ b/Astronomy/sdss_mosaics/SDSS_today.ipynb
@@ -57,7 +57,8 @@
     }
    ],
    "source": [
-    "!conda install conda-forge::astroquery"
+    "%pip install astroquery\n",
+    "%pip install MontagePy"
    ]
   },
   {
@@ -84,6 +85,9 @@
     "import warnings\n",
     "import sdss_archive\n",
     "import datetime\n",
+    "import SciServer\n",
+    "\n",
+    "from SciServer import Authentication\n",
     "\n",
     "from astropy.io import ascii\n",
     "\n",
@@ -106,9 +110,9 @@
     "workdir   = \"M51g\"\n",
     "\n",
     "# Use user storage\n",
-    "# TODO: Test on SciServer to make sure folder is accessible\n",
+    "# TODO: There is an issue with writing to the Temporary directory which this workdir should set to\n",
     "myUserName = Authentication.getKeystoneUserWithToken(Authentication.getToken()).userName\n",
-    "workdir = \"/home/idies/workspace/Storage/\" + myUserName + \"/montage_temp/\" + workdir + '/'"
+    "workdir = \"/home/idies/workspace/Storage/\" + myUserName + \"/persistent/montage_temp/\" + workdir + \"/\""
    ]
   },
   {
@@ -148,8 +152,9 @@
     "print(\"Work directory: \" + workdir, flush=True)\n",
     "\n",
     "try:\n",
-    "    os.makedirs(workdir)  \n",
-    "except:\n",
+    "    os.makedirs(workdir, exist_ok=True)  \n",
+    "except OSError as e :\n",
+    "    print(\"Failed to created folder at \" + workdir)\n",
     "    pass\n",
     "    \n",
     "os.chdir(workdir)\n",

--- a/Astronomy/sdss_mosaics/SDSS_today.ipynb
+++ b/Astronomy/sdss_mosaics/SDSS_today.ipynb
@@ -17,7 +17,9 @@
     "\n",
     "## Setup\n",
     "\n",
-    "The Montage Python package is a mixture of pure Python and Python binary extension code.  It can be downloaded using <tt style=\"color: #c00000;\">pip install MontagePy</tt>.  This notebook also assumes that Astropy and Astroquery have been installed.\n"
+    "The Montage Python package is a mixture of pure Python and Python binary extension code.  It can be downloaded using <tt style=\"color: #c00000;\">pip install MontagePy</tt>.  This notebook also assumes that Astropy and Astroquery have been installed.\n",
+    "\n",
+    "If the <tt style=\"color: #c00000;\">pip install</tt> don't resolve, please note that this notebook needs to be run inside of your `/Storage/` folder. \n"
    ]
   },
   {

--- a/Astronomy/sdss_mosaics/SDSS_today.ipynb
+++ b/Astronomy/sdss_mosaics/SDSS_today.ipynb
@@ -112,9 +112,8 @@
     "workdir   = \"M51g\"\n",
     "\n",
     "# Use user storage\n",
-    "# TODO: There is an issue with writing to the Temporary directory which this workdir should set to\n",
     "myUserName = Authentication.getKeystoneUserWithToken(Authentication.getToken()).userName\n",
-    "workdir = \"/home/idies/workspace/Storage/\" + myUserName + \"/persistent/montage_temp/\" + workdir + \"/\""
+    "workdir = \"/home/idies/workspace/Temporary/\" + myUserName + \"/scratch/montage_temp/\" + workdir + \"/\""
    ]
   },
   {

--- a/Astronomy/sdss_mosaics/SDSS_today.ipynb
+++ b/Astronomy/sdss_mosaics/SDSS_today.ipynb
@@ -105,7 +105,10 @@
     "band      = \"g\"\n",
     "workdir   = \"M51g\"\n",
     "\n",
-    "workdir = \"/home/idies/workspace/Temporary/raddick/montage_temp/\" + workdir + '/'"
+    "# Use user storage\n",
+    "# TODO: Test on SciServer to make sure folder is accessible\n",
+    "myUserName = Authentication.getKeystoneUserWithToken(Authentication.getToken()).userName\n",
+    "workdir = \"/home/idies/workspace/Storage/\" + myUserName + \"/montage_temp/\" + workdir + '/'"
    ]
   },
   {

--- a/Astronomy/sdss_mosaics/SDSS_today.ipynb
+++ b/Astronomy/sdss_mosaics/SDSS_today.ipynb
@@ -57,7 +57,7 @@
     }
    ],
    "source": [
-    "!conda install astroquery"
+    "!conda install conda-forge::astroquery"
    ]
   },
   {


### PR DESCRIPTION
There may be a few references to inaccessible folders inside of the SciServer and the github. This is one that I saw was referenced but I still need to test on the SciServer to make sure this notebook works as expected. 